### PR TITLE
Added "vec" mathfunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ It's possible to intermix scalar values and vectors:
     set x {1.0 2.0 3.0 4.0 5.0}
     set y [expr {sub(mul($x,2),1)}]
     # y: 1.0 3.0 5.0 7.0 9.0
+    
+Using the "vec" function, you can create a list with expressions.
+
+    set x 5.0
+    set y [expr {vec($x+1,$x*2,$x/4)}]
+    # y: 6.0 10.0 1.25
 
 # Usage
 

--- a/expr++.tcl
+++ b/expr++.tcl
@@ -39,6 +39,14 @@ namespace eval ::tcl::mathfunc::legacy {
    
    # Add new functions
    
+   # Basic math function to create a vector that accepts expr notation
+   # 
+   # set myvec [expr {vec(1,2,3+1)}]; # 1 2 4
+   
+   proc ::tcl::mathfunc::vec {args} {
+      return $args
+   }
+   
    # Nth root of X
    #
    # This is computed via


### PR DESCRIPTION
This simple mathfunc, which just returns the arguments, enables the user to construct a vector in comma-separated form, where each argument is parsed as an expression.

For example, take the existing implementation of cross-product in the ::math::linearalgebra package:

```tcl
# crossproduct --
#     Return the "cross product" of two 3D vectors
# Arguments:
#     vect1      First vector
#     vect2      Second vector
# Result:
#     Cross product
#
proc ::math::linearalgebra::crossproduct { vect1 vect2 } {

    if { [llength $vect1] == 3 && [llength $vect2] == 3 } {
        foreach {v11 v12 v13} $vect1 {v21 v22 v23} $vect2 {break}
        return [list \
            [expr {$v12*$v23 - $v13*$v22}] \
            [expr {$v13*$v21 - $v11*$v23}] \
            [expr {$v11*$v22 - $v12*$v21}] ]
    } else {
        return -code error "Cross-product only defined for 3D vectors"
    }
}
```

With the new "vec" mathfunc, it could be rewritten as follows:

```tcl
# crossproduct --
#     Return the "cross product" of two 3D vectors
# Arguments:
#     vect1      First vector
#     vect2      Second vector
# Result:
#     Cross product
#
proc ::math::linearalgebra::crossproduct { vect1 vect2 } {

    if { [llength $vect1] == 3 && [llength $vect2] == 3 } {
        foreach {v11 v12 v13} $vect1 {v21 v22 v23} $vect2 {break}
        return [expr {vec(
            $v12*$v23 - $v13*$v22, 
            $v13*$v21 - $v11*$v23, 
            $v11*$v22 - $v12*$v21
        )}]
    } else {
        return -code error "Cross-product only defined for 3D vectors"
    }
}
```